### PR TITLE
Add ModularMatrix type to represent the board, add command-line parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,121 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clearscreen"
@@ -26,6 +131,12 @@ dependencies = [
  "which",
  "winapi",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "dirs"
@@ -54,6 +165,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "errno"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +195,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "game_of_life"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "clearscreen",
  "rand",
  "sdl2",
@@ -80,6 +213,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +246,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "memchr"
@@ -109,7 +271,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -229,7 +391,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -244,12 +406,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "sdl2"
 version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7959277b623f1fb9e04aea73686c3ca52f01b2145f8ea16f4ff30d8b7623b1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "libc",
  "sdl2-sys",
@@ -277,6 +452,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -329,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,3 +559,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 rand = "0.8.5"
 clearscreen = "2.0.1"
 sdl2 = "0.35.2"
+clap = { version = "4.3.24", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use rand::Rng;
 use std::thread;
 use std::time::Duration;
 
+use clap::Parser;
+
 use sdl2::pixels::Color;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
@@ -11,87 +13,126 @@ use sdl2::rect::Rect;
 use sdl2::render::WindowCanvas;
 use sdl2::mouse::MouseButton;
 
-const FACTOR: usize = 100;
-const WIDTH: usize = 9 * FACTOR;
-const HEIGHT: usize = 9 * FACTOR;
-const SIZE: usize = 50;
-const RECT_WIDTH: usize = WIDTH / SIZE;
-const RECT_HEIGHT: usize = HEIGHT / SIZE;
+
+const DEFAULT_BOARD_WIDTH:  usize = 50;
+const DEFAULT_BOARD_HEIGHT: usize = 50;
+
+const CANVAS_WIDTH_PX: usize = 600;
+const CANVAS_HEIGHT_PX: usize = 600;
+
+const RECT_WIDTH_PX:  usize = CANVAS_WIDTH_PX  / DEFAULT_BOARD_WIDTH;
+const RECT_HEIGHT_PX: usize = CANVAS_HEIGHT_PX / DEFAULT_BOARD_HEIGHT;
 
 const NORMAL_SPEED: Duration = Duration::from_secs(1);
-const FAST_SPEED: Duration   = Duration::from_millis(50);
+const FAST_SPEED:   Duration = Duration::from_millis(50);
 
-fn do_step(array: &mut [[[i32;SIZE];SIZE];2], cur_matrix: usize) 
+
+mod colors {
+    use sdl2::pixels::Color;
+    pub const GRID:          Color = Color::RGB(0x93, 0xA1, 0xA1);
+    pub const FILLED_SQUARE: Color = Color::RGB(0x2A, 0xA1, 0x98);
+    pub const EMPTY_SQUARE:  Color = Color::RGB(0xFD, 0xF6, 0xE3);
+}
+
+
+// Configure command line parsing:
+#[derive(Parser)]
+struct Cli {
+
+    /// Number of columns in the board.
+    #[arg(long, default_value_t = DEFAULT_BOARD_WIDTH)]
+    board_width: usize,
+
+    /// Number of rows in the board.
+    #[arg(long, default_value_t = DEFAULT_BOARD_HEIGHT)]
+    board_height: usize,
+}
+
+
+// FIXME: The following two declarations allowed accessing `ModularMatrix`;
+// however this seems redundant:
+pub mod modular_matrix;
+use crate::modular_matrix::ModularMatrix;
+
+
+fn do_step(cur_matrix: &ModularMatrix<bool>, new_matrix: &mut ModularMatrix<bool>) 
 {
-    let mut counter;
-    for i in 0..SIZE {
-        for j in 0..SIZE {
-            // Assume the world is "modular", i.e. the border of one side is connected to the
-            // border on the other side.
-            counter =   array[cur_matrix][(i + SIZE - 1) % SIZE][(j + SIZE - 1) % SIZE] +
-                        array[cur_matrix][(i + SIZE - 1) % SIZE][(j + SIZE + 0) % SIZE] +
-                        array[cur_matrix][(i + SIZE - 1) % SIZE][(j + SIZE + 1) % SIZE] +
+    for i in 0 .. cur_matrix.width() {
+        let col = i as isize;
 
-                        array[cur_matrix][i] [(j + SIZE - 1) % SIZE] +
-                        array[cur_matrix][i] [(j + SIZE + 1) % SIZE] +
+        for j in 0 .. cur_matrix.height() {
+            let row = j as isize;
 
-                        array[cur_matrix][(i + SIZE + 1) % SIZE][(j + SIZE - 1) % SIZE] +
-                        array[cur_matrix][(i + SIZE + 1) % SIZE][(j + SIZE + 0) % SIZE] +
-                        array[cur_matrix][(i + SIZE + 1) % SIZE][(j + SIZE + 1) % SIZE];
+            let neighbor_count = 0
+                + if cur_matrix.get(col-1, row-1) {1} else {0} 
+                + if cur_matrix.get(col-1, row+0) {1} else {0} 
+                + if cur_matrix.get(col-1, row+1) {1} else {0} 
+                //
+                + if cur_matrix.get(col+0, row-1) {1} else {0} 
+                + if cur_matrix.get(col+0, row+1) {1} else {0} 
+                //
+                + if cur_matrix.get(col+1, row-1) {1} else {0} 
+                + if cur_matrix.get(col+1, row+0) {1} else {0} 
+                + if cur_matrix.get(col+1, row+1) {1} else {0} 
+            ;
 
-
-            array[1 - cur_matrix][i][j] = match array[cur_matrix][i][j] {
-                1 => {
-                    match counter {
-                        ..= 1 => 0,
-                        2 | 3 => 1,
-                        _     => 0,
+            new_matrix.set(col, row, match cur_matrix.get(col, row) {
+                true => {
+                    match neighbor_count {
+                        ..= 1 => false,
+                        2 | 3 => true,
+                        _     => false,
                     }
                 },
-                _ => {
-                    match counter {
-                        3 => 1,
-                        _ => 0,
+                false => {
+                    match neighbor_count {
+                        3 => true,
+                        _ => false,
                     }
                 }
-            }
+            });
         }
     }
 }
 
-fn init_world(array: &mut [[[i32; SIZE];SIZE];2], cur_matrix: usize, rng: &mut rand::rngs::ThreadRng, clear: bool)
+
+// Initialize the board
+fn init_world(matrix: &mut ModularMatrix<bool>, rng: &mut rand::rngs::ThreadRng, clear: bool)
 {
-    for i in 0..SIZE {
-        for j in 0..SIZE {
-            array[cur_matrix][i][j] = match clear {
-                true => 0,
+    for i in 0 .. matrix.width() {
+        for j in 0 .. matrix.height() {
+            matrix.set(i as isize, j as isize, match clear {
+                true => false,
                 false => {
                     match rng.gen_range(0..=100) {
-                        0..=85 => 0,
-                        _      => 1
+                        0..=85 => false,
+                        _      => true,
                     }
                 }
-            };
+            });
         }
     }
 }
 
-fn render_step(array: &[[[i32; SIZE];SIZE];2], cur_matrix: usize, canvas: &mut WindowCanvas)
+
+fn render_step(matrix: &ModularMatrix<bool>, canvas: &mut WindowCanvas)
 {
-    canvas.set_draw_color(Color::RGB(41, 41, 41));
+
+    // Fill the whole canvas with the color of the grid
+    canvas.set_draw_color(colors::GRID);
     canvas.clear();
 
-    for i in 0..SIZE {
-        for j in 0.. SIZE {
-            let x: usize = i * RECT_WIDTH;
-            let y: usize = j * RECT_HEIGHT;
-            let color: Color  = match array[cur_matrix][i][j] {
-                0 => Color::RGB(255, 255, 255),
-                _ => Color::RGB(0, 0, 0),
+    for i in 0 .. matrix.width() {
+        for j in 0 .. matrix.height() {
+            let x: usize = i * RECT_WIDTH_PX;
+            let y: usize = j * RECT_HEIGHT_PX;
+            let color: Color  = match matrix.get(i as isize, j as isize) {
+                false => colors::EMPTY_SQUARE,
+                true  => colors::FILLED_SQUARE,
             };
 
             canvas.set_draw_color(color);
-            let _ = canvas.fill_rect(Rect::new(x as i32 + 1, y as i32 + 1, RECT_WIDTH as u32 - 1, RECT_HEIGHT as u32 - 1));
+            let _ = canvas.fill_rect(Rect::new(x as i32 + 1, y as i32 + 1, RECT_WIDTH_PX as u32 - 1, RECT_HEIGHT_PX as u32 - 1));
         }
     }
     canvas.present();
@@ -100,29 +141,28 @@ fn render_step(array: &[[[i32; SIZE];SIZE];2], cur_matrix: usize, canvas: &mut W
 
 fn main() 
 {
-    
+    let config = Cli::parse();
+
     let mut rng = rand::thread_rng();
-    let mut cur_matrix = 0;
-    let mut array: [[[i32;SIZE];SIZE];2] = [[[0;SIZE];SIZE];2];
     let mut paused: bool = false;
     let mut clicked: bool = false;
     let mut current_rect_x: usize = std::usize::MAX;
     let mut current_rect_y: usize = std::usize::MAX;
     let mut speed = NORMAL_SPEED;
 
+    let mut cur_matrix = ModularMatrix::new(config.board_width, config.board_height, false);
+    let mut new_matrix = ModularMatrix::new(config.board_width, config.board_height, false);
 
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
 
-    let window = video_subsystem.window("Game of Life in Rust", 
-                                        WIDTH as u32, HEIGHT as u32)
-                                .position_centered()
-                                .build()
-                                .unwrap();
+    let window = video_subsystem.window(
+        "Game of Life in Rust", CANVAS_WIDTH_PX as u32, CANVAS_HEIGHT_PX as u32
+    ).position_centered().build().unwrap();
 
     let mut canvas = window.into_canvas().build().unwrap();
 
-    init_world(&mut array, cur_matrix, &mut rng, false);
+    init_world(&mut cur_matrix, &mut rng, false);
 
     let mut event_pump = sdl_context.event_pump().unwrap();
     'running: loop {
@@ -146,13 +186,13 @@ fn main()
 
                 Event::KeyDown { keycode: Some(Keycode::C), .. } => {
                     if paused {
-                        init_world(&mut array, cur_matrix, &mut rng, true);
+                        init_world(&mut cur_matrix, &mut rng, true);
                     }
                 },
 
                 Event::KeyDown { keycode: Some(Keycode::R), .. } => {
                     if paused {
-                        init_world(&mut array, cur_matrix, &mut rng, false);
+                        init_world(&mut cur_matrix, &mut rng, false);
                     }
                 },
 
@@ -161,12 +201,12 @@ fn main()
                     if !paused { break; }
 
                     clicked = true;
-                    let i = x as usize / RECT_WIDTH;
-                    let j = y as usize / RECT_HEIGHT;
-                    array[cur_matrix][i][j] = 1 - array[cur_matrix][i][j];
+                    let i = (x as usize / RECT_WIDTH_PX) as isize;
+                    let j = (y as usize/ RECT_HEIGHT_PX) as isize;
+                    cur_matrix.set(i, j, ! cur_matrix.get(i, j));
 
-                    current_rect_x = i;
-                    current_rect_y = j;
+                    current_rect_x = i as usize;
+                    current_rect_y = j as usize;
                 }
 
                 Event::MouseButtonUp { mouse_btn: MouseButton::Left, .. } => {
@@ -177,13 +217,13 @@ fn main()
 
                 Event::MouseMotion {x, y, ..} => {
                     if clicked {
-                        let i = x as usize / RECT_WIDTH;
-                        let j = y as usize / RECT_HEIGHT;
-                        if (current_rect_x != i) || (current_rect_y != j) {
-                            array[cur_matrix][i][j] = 1 - array[cur_matrix][i][j];
+                        let i = (x as usize / RECT_WIDTH_PX) as isize;
+                        let j = (y as usize/ RECT_HEIGHT_PX) as isize;
+                        if (current_rect_x != (i as usize)) || (current_rect_y != (j as usize)) {
+                            cur_matrix.set(i, j, ! cur_matrix.get(i, j));
 
-                            current_rect_x = i;
-                            current_rect_y = j;
+                            current_rect_x = i as usize;
+                            current_rect_y = j as usize;
                         }
                     }
                 }
@@ -192,14 +232,18 @@ fn main()
             }
         } // End event loop
         
-        render_step(&array, cur_matrix, &mut canvas);
+        render_step(&cur_matrix, &mut canvas);
         if paused {
             continue;
         }
 
-        do_step(&mut array, cur_matrix);
+        do_step(&cur_matrix, &mut new_matrix);
 
-        cur_matrix = 1 - cur_matrix;
+        // Swap matrices
+        let old_cur_matrix = cur_matrix;
+        cur_matrix = new_matrix;
+        new_matrix = old_cur_matrix;
+
         thread::sleep(speed);
 
     } // End game loop

--- a/src/modular_matrix.rs
+++ b/src/modular_matrix.rs
@@ -1,0 +1,71 @@
+/*
+ * Defines `ModularMatrix`, a generic type for representing two-dimensional vectors (arrays) whose
+ * indices "wrap-around"; in other words, any integral value can be used to get elements, the
+ * actual index in the array is calculated from using the mathematical modulo operation.
+ *
+ * Note that, since we are using `Vec`tors to store the actual matrix values, elements in the
+ * matrix require cloning and therefore their type must implement the `std::clone::Clone` trait.
+ *
+ * Also, because it is expected matrices of simple types (e.g. numbers) will be used more often, a simplification
+ * was made by requiring the elements' type to implement the `Copy` trait too.
+ */
+
+#[derive(Debug)]
+pub struct ModularMatrix<T: std::clone::Clone + Copy> {
+    width: usize,
+    height: usize,
+    elements: Vec<Vec<T>>, // two-dimensional vector
+}
+
+
+// FIXME: How to create a name for the constrained generic T:Foo+Bar to avoid repetition?
+impl<T: std::clone::Clone + Copy> ModularMatrix<T> {
+
+    // Constructor
+    pub fn new(width: usize, height: usize, init: T) -> ModularMatrix<T> {
+
+        let mut columns: Vec<Vec<T>> = vec![];
+
+        // Initialize all the matrix elements to `init`:
+        for _col in 0 .. width {
+            // TODO: There must be a more efficient way of doing this. 
+            columns.push( vec![init; height] );
+        }
+
+        ModularMatrix {
+            width,
+            height,
+            elements: columns,
+        }
+    }
+
+
+    // Returns the element at the given position.
+    pub fn get(&self, modular_column_idx: isize, modular_row_idx: isize) -> T {
+        let column_idx = modulo(modular_column_idx, self.width);
+        let row_idx    = modulo(modular_row_idx,    self.height);
+        self.elements[column_idx][row_idx]
+    }
+
+    // Sets the element at the given position and returns it.
+    pub fn set(&mut self, modular_column_idx: isize, modular_row_idx: isize, element_value: T) -> T {
+        let column_idx = modulo(modular_column_idx, self.width);
+        let row_idx    = modulo(modular_row_idx,    self.height);
+        self.elements[column_idx][row_idx] = element_value;
+        element_value
+    }
+
+    // Returns the number of columns in the matrix:
+    pub fn width(&self) -> usize { self.width }
+
+    // Returns the number of rows in the matrix:
+    pub fn height(&self) -> usize { self.height }
+}
+
+// Calculates the (mathematical) modulo operation.
+// The result should always be a value between `0` and `radix - 1`.
+fn modulo(integer: isize, radix: usize) -> usize {
+    let iradix: isize = radix as isize;
+    ( (integer + iradix) % iradix ) as usize 
+}
+


### PR DESCRIPTION
- Change board representation to use two `ModularMatrix<bool>` objects instead of the previous three-dimensional array of ints
- Add command-line options to specify the dimensions of the board
- Refactor a bit to improve readability
- Change default color scheme to solarized